### PR TITLE
Add dead commandset

### DIFF
--- a/commands/dead_cmdset.py
+++ b/commands/dead_cmdset.py
@@ -1,0 +1,37 @@
+from evennia import CmdSet
+from evennia.commands.command import Command
+
+
+class CmdDeadLook(Command):
+    """Simple look replacement for dead characters."""
+
+    key = "look"
+    aliases = ["l", "examine", "exa", "search"]
+    locks = "cmd:all()"
+
+    def func(self):
+        self.caller.msg("Everything is dark. You are dead.")
+
+
+class CmdDeadNoCommand(Command):
+    """Catch-all command blocking actions when dead."""
+
+    key = "dead_noop"
+    aliases = ["*"]
+    locks = "cmd:all()"
+    arg_regex = r".*"
+
+    def func(self):
+        self.caller.msg("You are dead and cannot do that.")
+
+
+class DeadCmdSet(CmdSet):
+    """Command set for dead characters."""
+
+    key = "DeadCmdSet"
+    priority = 110
+    mergetype = "Replace"
+
+    def at_cmdset_creation(self):
+        self.add(CmdDeadLook())
+        self.add(CmdDeadNoCommand())

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -10,10 +10,27 @@ creation commands.
 
 from evennia.objects.objects import DefaultCharacter
 
+from commands.dead_cmdset import DeadCmdSet
+
 from .objects import ObjectParent
 
 
-class Character(ObjectParent, DefaultCharacter):
+class LivingMixin:
+    """Common functionality for all living entities."""
+
+    is_pc = False
+
+    def at_death(self):
+        """Handle death of this entity."""
+        if self.location:
+            self.location.msg_contents(
+                "$You() collapse lifelessly.",
+                from_obj=self,
+            )
+        self.db.is_dead = True
+
+
+class Character(LivingMixin, ObjectParent, DefaultCharacter):
     """Represents the in-game character entity.
 
     Two new persistent Attributes are introduced on all characters:
@@ -22,11 +39,14 @@ class Character(ObjectParent, DefaultCharacter):
     both values.
     """
 
+    is_pc = True
+
     def at_object_creation(self):
         """Called once, when the object is first created."""
         super().at_object_creation()
         self.db.hunger = 0
         self.db.thirst = 0
+        self.db.is_dead = False
 
     def at_init(self):
         """Called whenever the typeclass is cached from memory."""
@@ -35,3 +55,12 @@ class Character(ObjectParent, DefaultCharacter):
             self.db.hunger = 0
         if self.db.thirst is None:
             self.db.thirst = 0
+        if self.db.is_dead is None:
+            self.db.is_dead = False
+        if self.db.is_dead:
+            self.cmdset.add(DeadCmdSet, permanent=True)
+
+    def at_death(self):
+        """Handle character-specific death effects."""
+        super().at_death()
+        self.cmdset.add(DeadCmdSet, permanent=True)


### PR DESCRIPTION
## Summary
- implement `DeadCmdSet` with commands blocking all actions
- add commandset in `Character.at_death` and `at_init`

## Testing
- `python - <<'PY'
import py_compile, subprocess
files = subprocess.check_output(['git','ls-files','*.py']).decode().split()
for f in files:
    py_compile.compile(f, doraise=True)
print('compiled', len(files), 'files')
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68436b9a7188832da2a6956b740a44e9