### PR TITLE
Fix dead cmdset being too strict

### DIFF
--- a/commands/dead_cmdset.py
+++ b/commands/dead_cmdset.py
@@ -13,25 +13,11 @@ class CmdDeadLook(Command):
         self.caller.msg("Everything is dark. You are dead.")
 
 
-class CmdDeadNoCommand(Command):
-    """Catch-all command blocking actions when dead."""
-
-    key = "dead_noop"
-    aliases = ["*"]
-    locks = "cmd:all()"
-    arg_regex = r".*"
-
-    def func(self):
-        self.caller.msg("You are dead and cannot do that.")
-
-
 class DeadCmdSet(CmdSet):
     """Command set for dead characters."""
 
     key = "DeadCmdSet"
     priority = 110
-    mergetype = "Replace"
 
     def at_cmdset_creation(self):
         self.add(CmdDeadLook())
-        self.add(CmdDeadNoCommand())


### PR DESCRIPTION
## Summary
- allow all normal commands while dead
- remove catch-all block in `DeadCmdSet`

## Testing
- `evennia migrate`
- `evennia test --settings settings.py .`

------
https://chatgpt.com/codex/tasks/task_e_68437a197b14832dbfe76a698f4127e2