### PR TITLE
Add metabolism-based hunger timer

### DIFF
--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -101,3 +101,22 @@ class Script(DefaultScript):
     """
 
     pass
+
+
+class MetabolismScript(DefaultScript):
+    """Regularly increase hunger and thirst on a living object."""
+
+    def at_script_creation(self):
+        """Called once when first created."""
+        self.key = "metabolism_script"
+        self.persistent = True
+        self.interval = self.obj.get_metabolism_interval()
+
+    def at_repeat(self):
+        """Increase hunger and thirst each tick."""
+        if not self.obj.db.is_living:
+            return
+        self.obj.increase_hunger()
+        self.obj.increase_thirst()
+        # update interval in case metabolism changed
+        self.interval = self.obj.get_metabolism_interval()


### PR DESCRIPTION
## Summary
- add is_living and metabolism attributes on living objects
- start/stop a metabolism script on living entities
- implement `MetabolismScript` to raise hunger and thirst periodically
- fix is_living initialization so loading characters works without errors

## Testing
- `evennia test --settings settings.py .`


------
https://chatgpt.com/codex/tasks/task_e_68438b98f6f8832d9e4f82a8b16c4612