### PR TITLE
Translate eat command

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -16,7 +16,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 
 from evennia import default_cmds
 from .drink import CmdDrink
-from .comer import CmdComer
+from .eat import CmdEat
 from .liquid import CmdFill, CmdEmpty
 
 
@@ -38,7 +38,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
-        self.add(CmdComer())
+        self.add(CmdEat())
         self.add(CmdFill())
         self.add(CmdEmpty())
         self.add(CmdDrink())

--- a/commands/eat.py
+++ b/commands/eat.py
@@ -1,20 +1,20 @@
-"""Comer command for consuming Food objects."""
+"""Eat command for consuming Food objects."""
 from evennia.utils.utils import inherits_from
 
 from .command import Command
 
 
-class CmdComer(Command):
+class CmdEat(Command):
     """Eat an edible item to reduce hunger."""
 
-    key = "comer"
+    key = "eat"
     locks = "cmd:all()"
     arg_regex = r"\s|$"
 
     def func(self):
         caller = self.caller
         if not self.args:
-            caller.msg("O que voce quer comer?")
+            caller.msg("What do you want to eat?")
             return
 
         obj = caller.search(
@@ -26,7 +26,7 @@ class CmdComer(Command):
             return
 
         if not inherits_from(obj, "typeclasses.food.FoodMixin"):
-            caller.msg("Voce nao pode comer isso.")
+            caller.msg("You can't eat that.")
             return
 
         obj.eat(caller)


### PR DESCRIPTION
## Summary
- translate eat command messages to English
- rename command file to `eat.py`
- update default commandset to use `CmdEat`

## Testing
- `evennia test --settings settings.py .`

------
https://chatgpt.com/codex/tasks/task_e_68441e3b39dc832dbd8e4bbce5cf26dd