### PR TITLE
Fix fill limits and empty container message

### DIFF
--- a/commands/drink.py
+++ b/commands/drink.py
@@ -19,7 +19,7 @@ class CmdDrink(Command):
         obj = caller.search(self.target, location=caller.location)
         if not obj:
             return
-        if not inherits_from(obj, "typeclasses.liquid.LiquidContainerMixin") or not obj.has_liquid():
+        if not inherits_from(obj, "typeclasses.liquid.LiquidContainerMixin"):
             caller.msg("You can't drink from that.")
             return
         obj.drink_liquid(caller)

--- a/typeclasses/liquid.py
+++ b/typeclasses/liquid.py
@@ -73,7 +73,7 @@ class LiquidContainerMixin:
     def drink_liquid(self, drinker, amount: int = 1):
         """Consume liquid from this container."""
         if not self.has_liquid():
-            drinker.msg(f"{self.get_display_name(drinker)} is empty.")
+            drinker.msg("The container is empty.")
             return
         if utils.inherits_from(drinker, "typeclasses.characters.LivingMixin"):
             drinker.decrease_thirst(20)
@@ -114,7 +114,10 @@ class LiquidContainerMixin:
                 filler.msg(f"{self.get_display_name(filler)} is already full.")
             return
 
-        transfer = min(available, source.get_liquid_amount())
+        if source.db.is_water_source:
+            transfer = available
+        else:
+            transfer = min(available, source.get_liquid_amount())
         self.db.liquid = source.get_liquid()
         self.db.liquid_amount = (self.db.liquid_amount or 0) + transfer
         if not source.db.is_water_source:


### PR DESCRIPTION
## Summary
- allow water sources to fully fill other containers without tracking capacity
- prevent `drink` command from blocking containers with no liquid
- clarify feedback when trying to drink from an empty container

## Testing
- `evennia test --settings settings.py .`

------
https://chatgpt.com/codex/tasks/task_e_68446a096b60832da0dfe0f79e74ed80