### PR TITLE
Improve liquid commands search

### DIFF
--- a/commands/drink.py
+++ b/commands/drink.py
@@ -1,5 +1,4 @@
 from evennia.commands.command import Command
-from evennia.utils.utils import inherits_from
 
 class CmdDrink(Command):
     """Drink from a nearby water source."""
@@ -16,10 +15,13 @@ class CmdDrink(Command):
         if not self.target:
             caller.msg("Drink from what?")
             return
-        obj = caller.search(self.target, location=caller.location)
-        if not obj:
+        objs = caller.search(
+            self.target,
+            location=caller.location,
+            quiet=True,
+            typeclass="typeclasses.liquid.LiquidContainerMixin",
+        )
+        if not objs:
             return
-        if not inherits_from(obj, "typeclasses.liquid.LiquidContainerMixin"):
-            caller.msg("You can't drink from that.")
-            return
+        obj = objs[0]
         obj.drink_liquid(caller)

--- a/commands/liquid.py
+++ b/commands/liquid.py
@@ -1,7 +1,6 @@
 """Commands for interacting with LiquidContainerMixin objects."""
 
 from evennia.commands.command import Command
-from evennia.utils.utils import inherits_from
 
 
 class CmdFill(Command):
@@ -27,15 +26,22 @@ class CmdFill(Command):
         if not self.dest_name or not self.source_name:
             self.caller.msg("Usage: fill <dest> <source>")
             return
-        dest = self.caller.search(self.dest_name)
-        if not dest:
+        dest_candidates = self.caller.search(
+            self.dest_name,
+            quiet=True,
+            typeclass="typeclasses.liquid.LiquidContainerMixin",
+        )
+        if not dest_candidates:
             return
-        source = self.caller.search(self.source_name)
-        if not source:
+        source_candidates = self.caller.search(
+            self.source_name,
+            quiet=True,
+            typeclass="typeclasses.liquid.LiquidContainerMixin",
+        )
+        if not source_candidates:
             return
-        if not (inherits_from(dest, "typeclasses.liquid.LiquidContainerMixin") and inherits_from(source, "typeclasses.liquid.LiquidContainerMixin")):
-            self.caller.msg("Both objects must be liquid containers.")
-            return
+        dest = dest_candidates[0]
+        source = source_candidates[0]
         dest.fill_from_container(source, filler=self.caller)
 
 
@@ -56,10 +62,12 @@ class CmdEmpty(Command):
         if not self.container_name:
             self.caller.msg("Empty what?")
             return
-        container = self.caller.search(self.container_name)
-        if not container:
+        container_candidates = self.caller.search(
+            self.container_name,
+            quiet=True,
+            typeclass="typeclasses.liquid.LiquidContainerMixin",
+        )
+        if not container_candidates:
             return
-        if not inherits_from(container, "typeclasses.liquid.LiquidContainerMixin"):
-            self.caller.msg("You can't empty that.")
-            return
+        container = container_candidates[0]
         container.empty_liquid(emptier=self.caller)


### PR DESCRIPTION
## Summary
- make `drink`, `fill`, and `empty` use `quiet=True` when searching
- filter searches so only `LiquidContainerMixin` objects match

## Testing
- `evennia test --settings settings.py .`

------
https://chatgpt.com/codex/tasks/task_e_684478cb6a1c832d9ef6f55377a8764e