### PR TITLE
Add rest command and tiredness recovery

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -18,6 +18,7 @@ from evennia import default_cmds
 from .drink import CmdDrink
 from .eat import CmdEat
 from .liquid import CmdFill, CmdEmpty
+from .rest import CmdRest
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -42,6 +43,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdFill())
         self.add(CmdEmpty())
         self.add(CmdDrink())
+        self.add(CmdRest())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/commands/rest.py
+++ b/commands/rest.py
@@ -1,0 +1,33 @@
+from evennia.utils import utils
+from .command import Command
+
+
+class CmdRest(Command):
+    """Toggle resting to recover tiredness."""
+
+    key = "rest"
+    locks = "cmd:all()"
+
+    def func(self):
+        caller = self.caller
+        if not utils.inherits_from(caller, "typeclasses.characters.LivingMixin"):
+            caller.msg("You can't rest.")
+            return
+        if caller.db.is_resting:
+            caller.db.is_resting = False
+            caller.msg("You stop resting.")
+            location = caller.location
+            if location:
+                location.msg_contents(
+                    f"{caller.get_display_name(location)} gets back up.",
+                    exclude=caller,
+                )
+        else:
+            caller.db.is_resting = True
+            caller.msg("You settle down to rest.")
+            location = caller.location
+            if location:
+                location.msg_contents(
+                    f"{caller.get_display_name(location)} lies down to rest.",
+                    exclude=caller,
+                )

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -26,6 +26,7 @@ class LivingMixin:
         self.db.hunger = 0
         self.db.thirst = 0
         self.db.tiredness = 0
+        self.db.is_resting = False
         self.db.is_dead = False
         self.db.is_living = True
         self.db.metabolism = 1.0
@@ -45,6 +46,8 @@ class LivingMixin:
             self.db.thirst = 0.0
         if self.db.tiredness is None:
             self.db.tiredness = 0.0
+        if self.db.is_resting is None:
+            self.db.is_resting = False
         if self.db.is_dead is None:
             self.db.is_dead = False
         if self.db.is_living:
@@ -61,6 +64,7 @@ class LivingMixin:
             )
         self.db.is_dead = True
         self.db.is_living = False
+        self.db.is_resting = False
         self.stop_metabolism_script()
 
     # Hunger/thirst/tiredness management helpers

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -118,6 +118,11 @@ class MetabolismScript(DefaultScript):
             return
         self.obj.increase_hunger()
         self.obj.increase_thirst()
-        self.obj.increase_tiredness()
+        if self.obj.db.is_resting:
+            tiredness = self.obj.db.tiredness or 0
+            recovery = 1 + tiredness / 20
+            self.obj.decrease_tiredness(recovery)
+        else:
+            self.obj.increase_tiredness()
         # update interval in case metabolism changed
         self.interval = self.obj.get_metabolism_interval()


### PR DESCRIPTION
## Summary
- introduce `rest` command to toggle resting state
- store `is_resting` on characters
- have metabolism script recover tiredness when resting
- include rest command in default cmdset

## Testing
- `evennia test --settings settings.py .`

------
https://chatgpt.com/codex/tasks/task_e_684492ef4818832da27238474bf6c6b1